### PR TITLE
Remove container first before attempting to start it

### DIFF
--- a/docker/files/service_file.jinja
+++ b/docker/files/service_file.jinja
@@ -8,6 +8,7 @@
 {%- set stopoptions = stopoptions|join(' ') %}
 {%- set args = args|join(' ') %}
 
+{%- set docker_prestart_remove_command = "rm -f %s"|format(name) %}
 {%- set docker_start_command = "run %s --name=%s %s %s %s"|format(runoptions, name, container.image, cmd, args)  %}
 {%- set docker_stop_command = "stop %s %s"|format(stopoptions, name) %}
 {%- set docker_poststop_command = "rm -f %s"|format(name) %}

--- a/docker/files/systemd.conf
+++ b/docker/files/systemd.conf
@@ -5,6 +5,7 @@ After=docker.service
 
 {%- set remove_on_stop = container.get("remove_on_stop", False) %}
 {%- set pull_before_start = container.get("pull_before_start") or False %}
+{%- set remove_before_start = container.get("remove_before_start") or False %}
 
 [Service]
 Restart=always
@@ -12,6 +13,9 @@ Restart=always
 ExecStartPre=/usr/bin/docker pull {{ container.image }}
 {%- endif %}
 
+{%- if remove_before_start %}
+ExecStartPre=-/usr/bin/docker {{ docker_prestart_remove_command }}
+{%- endif %}
 ExecStart=/usr/bin/docker {{ docker_start_command }}
 ExecStop=/usr/bin/docker {{ docker_stop_command }}
 {%- if remove_on_stop %}

--- a/docker/files/upstart.conf
+++ b/docker/files/upstart.conf
@@ -11,10 +11,17 @@ respawn
 {%- set cmd = container.get("cmd", "") %}
 
 {%- set pull_before_start = container.get("pull_before_start") or False %}
+{%- set remove_before_start = container.get("remove_before_start") or False %}
 
 {%- if pull_before_start %}
 pre-start script
   /usr/bin/docker pull {{ container.image }}
+end script
+{%- endif %}
+
+{%- if remove_before_start %}
+pre-start script
+  /usr/bin/docker rm -f {{ name }}
 end script
 {%- endif %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -10,8 +10,10 @@ docker-containers:
       #image: 'docker.io/registry:latest'  ##Fedora
       image: "registry:latest"
       cmd:
-      # Pull image on service restart (useful if you override the same tag. example: latest)
+      # Pull image on service start (useful if you override the same tag. example: latest)
       pull_before_start: True
+      # Remove container on service start
+      remove_before_start: False
       # Do not force container removal on stop (unless true)
       remove_on_stop: false
       runoptions:
@@ -33,8 +35,10 @@ docker-containers:
       args:
         - '-config.file=/prom-data/prometheus.yml'
         - '-storage.local.path=/prom-data/data/'
-      # Pull image on service restart (useful if you override the same tag. example: latest)
+      # Pull image on service start (useful if you override the same tag. example: latest)
       pull_before_start: True
+      # Remove container on service start
+      remove_before_start: False
       # Do not force container removal on stop (unless true)
       remove_on_stop: false
       runoptions:


### PR DESCRIPTION
In case it was already created.

This should avoid this problem when trying to start the service (and the container was created but not running):

```
/usr/bin/docker: Error response from daemon: Conflict. The container name "/ecs-agent" is already in use by container "22cb0febefdfe96ba2558dd33329fb428c7ed45a2145361d25e8faf331b18428". You have to remove (or rename) that container to be able to reuse that name.
```