### PR TITLE
Avoid setting multiple pre-start stanzas in upstart

### DIFF
--- a/docker/files/upstart.conf
+++ b/docker/files/upstart.conf
@@ -13,15 +13,15 @@ respawn
 {%- set pull_before_start = container.get("pull_before_start") or False %}
 {%- set remove_before_start = container.get("remove_before_start") or False %}
 
-{%- if pull_before_start %}
+{%- if pull_before_start or remove_before_start -%}
 pre-start script
+{%- if pull_before_start %}
   /usr/bin/docker pull {{ container.image }}
-end script
 {%- endif %}
 
 {%- if remove_before_start %}
-pre-start script
   /usr/bin/docker rm -f {{ name }}
+{%- endif %}
 end script
 {%- endif %}
 


### PR DESCRIPTION
I already got this merged into upstream here: https://github.com/saltstack-formulas/docker-formula/pull/239

According to the [upstart init manpages](https://manpages.ubuntu.com/manpages/trusty/man5/init.5.html):

    If a stanza is duplicated, the last occurence will be used.

So if someone has set both vars pull_before_start and remove_before_start to true, then there could be two pre-start script stanzas, of which upstart would only accept the last one, which isn't ideal behavior.

This change groups both scripts to run under one pre-start script stanza.