### PR TITLE
Login before dockering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,12 @@ Install and run Docker daemon
     You can override the default docker daemon options by setting each line in the *"docker-pkg:lookup:config"* pillar. This effectively writes the config in */etc/default/docker*. See *pillar.example*
 
 
+``docker.authenticate``
+-----------------------
+
+If the pillar `dockerhub_auth` exists, the username and password keys will be used to run a `docker login` for the root user, and hopefully further
+docker commands will use that auth.
+    
 ``docker.containers``
 ---------------------
 

--- a/docker/authenticate.sls
+++ b/docker/authenticate.sls
@@ -1,5 +1,13 @@
 {% if salt['pillar.get']('dockerhub_auth') %}
 
+# Need to install gnupg2 and pass to satisfy dockers credtnials helper I think
+
+creds installatio:
+  pkg.installed:
+    pkgs:
+      - gnupg2
+      - pass
+
 docker login -u {{ salt['pillar.get']('dockerhub_auth')['username'] }} -p {{ salt['pillar.get']('dockerhub_auth')['password'] }}:
   cmd.run
 

--- a/docker/authenticate.sls
+++ b/docker/authenticate.sls
@@ -4,7 +4,7 @@
 
 creds installatio:
   pkg.installed:
-    pkgs:
+    - pkgs:
       - gnupg2
       - pass
 

--- a/docker/authenticate.sls
+++ b/docker/authenticate.sls
@@ -1,6 +1,6 @@
 {% if salt['pillar.get']('dockerhub_auth') %}
 
-docker login -u {{ salt['pillar.get']('dockerhub_auth')['password'] }} -p {{ salt['pillar.get']('dockerhub_auth')['password'] }}:
+docker login -u {{ salt['pillar.get']('dockerhub_auth')['username'] }} -p {{ salt['pillar.get']('dockerhub_auth')['password'] }}:
   cmd.run
 
 {% endif %}

--- a/docker/authenticate.sls
+++ b/docker/authenticate.sls
@@ -1,0 +1,6 @@
+{% if salt['pillar.get']('dockerhub_auth') %}
+
+echo {{ salt['pillar.get']('dockerhub_auth')['password'] }} | docker login -u {{ salt['pillar.get']('dockerhub_auth')['password'] }} --password-stdin:
+  cmd.run
+
+{% endif %}

--- a/docker/authenticate.sls
+++ b/docker/authenticate.sls
@@ -1,6 +1,6 @@
 {% if salt['pillar.get']('dockerhub_auth') %}
 
-echo {{ salt['pillar.get']('dockerhub_auth')['password'] }} | docker login -u {{ salt['pillar.get']('dockerhub_auth')['password'] }} --password-stdin:
+docker login -u {{ salt['pillar.get']('dockerhub_auth')['password'] }} -p {{ salt['pillar.get']('dockerhub_auth')['password'] }}:
   cmd.run
 
 {% endif %}

--- a/docker/containers.sls
+++ b/docker/containers.sls
@@ -4,6 +4,7 @@
 
 include:
   - docker
+  - authenticate
 
 {% for name, container in containers.items() %}
 docker-image-{{ name }}:


### PR DESCRIPTION
This is an attempt to provide a fix for docker limits - if the salt pillars contain the appropriate keys, plant those keys into root's docker config. The hope is that the python APIs that salt etc. use to pull the images they use will access the docker config, or at least if we need to do a manual fix, the credentials are present.