### PR TITLE
PT-4536 Fix salt error when it is looking for authenticate.sls

### DIFF
--- a/docker/authenticate.sls
+++ b/docker/authenticate.sls
@@ -2,7 +2,7 @@
 
 # Need to install gnupg2 and pass to satisfy dockers credtnials helper I think
 
-creds installatio:
+creds-installation:
   pkg.installed:
     - pkgs:
       - gnupg2

--- a/docker/containers.sls
+++ b/docker/containers.sls
@@ -4,7 +4,7 @@
 
 include:
   - docker
-  - authenticate
+  - docker/authenticate
 
 {% for name, container in containers.items() %}
 docker-image-{{ name }}:


### PR DESCRIPTION
This is fixing the error -

``` ccl
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/docker/containers.sls' using 'yaml' renderer: 0.00607800483704
[DEBUG   ] Could not find file 'salt://authenticate.sls' in saltenv 'base'
[DEBUG   ] Could not find file 'salt://authenticate/init.sls' in saltenv 'base'
[DEBUG   ] compile template: False
[ERROR   ] Template was specified incorrectly: False
[DEBUG   ] Initializing new AsyncZeroMQReqChannel for (u'/etc/salt/pki/minion', u'clip_filter_prodvpc-us-east-1_20201125_0db354981773fa482', u'tcp://172.29.57.227:4506', u'aes')
[DEBUG   ] Initializing new AsyncAuth for (u'/etc/salt/pki/minion', u'clip_filter_prodvpc-us-east-1_20201125_0db354981773fa482', u'tcp://172.29.57.227:4506')
[DEBUG   ] Connecting the Minion to the Master URI (for the return server): tcp://172.29.57.227:4506
[DEBUG   ] Trying to connect to: tcp://172.29.57.227:4506
[DEBUG   ] LazyLoaded highstate.output
local:
    Data failed to compile:
----------
    Specified SLS authenticate in saltenv base is not available on the salt master or through a configured fileserver
```

Tested successfully in PT -

``` hcl
  Name: creds-installation - Function: pkg.installed - Result: Changed Started: - 04:10:08.603525 Duration: 5355.729 ms
  Name: docker login -u libratoinc -p docker4librato! - Function: cmd.run - Result: Changed Started: - 04:10:13.962666 Duration: 94.084 ms
  Name: docker pull amazon/amazon-ecs-agent:latest | grep "Image is up to date" >/dev/null 2>&1 || echo "changed=yes comment='Image updated'" - Function: cmd.run - Result: Clean Started: - 04:10:14.058020 Duration: 173.951 ms
  Name: /etc/systemd/system/docker-ecs-agent.service - Function: file.managed - Result: Clean Started: - 04:10:14.236284 Duration: 54.453 ms
  Name: docker-ecs-agent - Function: service.running - Result: Clean Started: - 04:10:14.875633 Duration: 30.913 ms
Summary for local
--------------
Succeeded: 143 (changed=3)
Failed:      0
--------------
Total states run:     143
Total run time:    16.693 s
```