### PR TITLE
Separate the namespace with the `.`

### DIFF
--- a/docker/containers.sls
+++ b/docker/containers.sls
@@ -4,7 +4,7 @@
 
 include:
   - docker
-  - docker/authenticate
+  - docker.authenticate
 
 {% for name, container in containers.items() %}
 docker-image-{{ name }}:


### PR DESCRIPTION
use the `.` as a namespace separator.